### PR TITLE
nb_conda_kernels 2.5.2: Rebuild for py313 on win-64

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,7 @@ source:
   sha256: 6474e7f5889f87ad20a539d45020ba07dd8fc73c82aba71290d855b1fbf048a7
 
 build:
-  # notebook <7 isn't available for py>=312 on s390x
-  skip: true  # [s390x]
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/Anaconda-Platform/nb_conda_kernels/archive/{{ version }}.tar.gz
-  sha256: 6474e7f5889f87ad20a539d45020ba07dd8fc73c82aba71290d855b1fbf048a7
+  sha256: f987a852e077eeed3614b9cc16012ba3f2be52a5e8eb07a2191ad9975b282178
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/Anaconda-Platform/nb_conda_kernels/archive/{{ version }}.tar.gz
+  url: https://github.com/anaconda/nb_conda_kernels/archive/{{ version }}.tar.gz
   sha256: f987a852e077eeed3614b9cc16012ba3f2be52a5e8eb07a2191ad9975b282178
 
 build:
@@ -56,7 +56,7 @@ test:
     - python -m pytest -v -m "not testbed" tests --disable-pytest-warnings
 
 about:
-  home: https://github.com/Anaconda-Platform/nb_conda_kernels
+  home: https://github.com/anaconda/nb_conda_kernels
   summary: Package for managing conda environment-based kernels inside of Jupyter
   description: |
     This extension enables a Jupyter Notebook or JupyterLab application


### PR DESCRIPTION

[PKG-7903](https://anaconda.atlassian.net/browse/PKG-7903)

There are missing py313 artifacts on win-64.
My suggestion is that `sha256` has been changed because the `nb_conda_kernels` repo was moved from `Anaconda-Platform` to `anaconda` org on GitHub. 

[PKG-7903]: https://anaconda.atlassian.net/browse/PKG-7903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ